### PR TITLE
Add Markdown (md) support

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -245,6 +245,7 @@ pub static MIME_TYPES: &'static [(&'static str, &'static str)] = &[
     ("manifest", "application/x-ms-manifest"),
     ("map", "text/plain"),
     ("master", "application/xml"),
+    ("md", "text/x-markdown"),
     ("mda", "application/msaccess"),
     ("mdb", "application/x-msaccess"),
     ("mde", "application/msaccess"),


### PR DESCRIPTION
There is a proposal to use "text/markdown" but it is still a draft
(https://datatracker.ietf.org/doc/draft-ietf-appsawg-text-markdown/)
in RFC editor queue so it seems wise to use "text/x-markdown" as long
as it is not official (see http://stackoverflow.com/a/25812177 for a
discussion on Markdown's mime type on Stack overflow).