### PR TITLE
Use Unicase to remove allocation when uppercase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ bench = []
 
 [dependencies]
 mime = ">=0.1, <0.3"
-phf = "0.7"
+phf = { version = "0.7", features = ["unicase"] }
+unicase = "1.1"
 
 [build-dependencies]
 phf_codegen = "0.7"
+unicase = "1.1"

--- a/src/gen_mime_types.rs
+++ b/src/gen_mime_types.rs
@@ -1,4 +1,7 @@
 extern crate phf_codegen;
+extern crate unicase;
+
+use unicase::UniCase;
 
 use std::fs::File;
 use std::io::prelude::*;
@@ -8,19 +11,19 @@ const GENERATED_FILE: &'static str = "src/mime_types_generated.rs";
 
 mod mime_types;
 
-fn main() { 
+fn main() {
     let mime_types: Vec<_> = mime_types::MIME_TYPES.iter()
         .map(|&(k, v)| (k.to_lowercase(), v))
         .collect();
 
     let mut outfile = BufWriter::new(File::create(GENERATED_FILE).unwrap());
 
-    write!(outfile, "static MIME_TYPES: phf::Map<&'static str, &'static str> = ").unwrap();    
-    
-    let mut map = phf_codegen::Map::<&str>::new();
+    write!(outfile, "static MIME_TYPES: phf::Map<UniCase<&'static str>, &'static str> = ").unwrap();
+
+    let mut map = phf_codegen::Map::<UniCase<&str>>::new();
 
     for &(ref key, val) in &mime_types {
-        map.entry(key, &format!("{:?}", val));
+        map.entry(UniCase(key), &format!("{:?}", val));
     }
 
     map.build(&mut outfile).unwrap();


### PR DESCRIPTION
This brings the benchmarks down from 60ns/350ns to 50ns/50ns for lowercase/uppercase on my machine.